### PR TITLE
pas-lab-be prefix for upload

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -718,14 +718,14 @@ class App(MiddlewareMixin, LifespanMixin):
         if Upload.is_used or upload_is_used_marker.exists():
             # To upload files.
             self._api.add_route(
-                str(constants.Endpoint.UPLOAD),
+                '/pas-lab-be' + str(constants.Endpoint.UPLOAD),
                 upload(self),
                 methods=["POST"],
             )
 
             # To access uploaded files.
             self._api.mount(
-                str(constants.Endpoint.UPLOAD),
+                '/pas-lab-be' + str(constants.Endpoint.UPLOAD),
                 StaticFiles(directory=get_upload_dir()),
                 name="uploaded_files",
             )

--- a/reflex/constants/event.py
+++ b/reflex/constants/event.py
@@ -33,7 +33,7 @@ class Endpoint(Enum):
 
         # Get the API URL from the config.
         config = get_config()
-        url = "".join([config.api_url, str(self)])
+        url = "".join([config.api_url, '/pas-lab-be', str(self)])
 
         # The event endpoint is a websocket.
         if self == Endpoint.EVENT:


### PR DESCRIPTION
Update upload route and static files mount to use the proxy prefix,
matching the existing _event websocket configuration. Also update
Endpoint.get_url() so env.json includes the prefix for frontend URLs.

Assisted with AI
