### PR TITLE
fix pas-lab prefix

### DIFF
--- a/reflex/constants/event.py
+++ b/reflex/constants/event.py
@@ -33,7 +33,7 @@ class Endpoint(Enum):
 
         # Get the API URL from the config.
         config = get_config()
-        url = "".join([config.api_url, '/pas-lab-be', str(self)])
+        url = "".join([config.api_url, str(self)])
 
         # The event endpoint is a websocket.
         if self == Endpoint.EVENT:


### PR DESCRIPTION
- **Add /pas-lab-be proxy prefix to upload endpoints**
- **Revert duplicate proxy prefix in endpoint URL generation**
